### PR TITLE
Improvement: don't attempt to execute XML files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,18 @@ FROM python:2-alpine
 
 MAINTAINER Arkivum Limited
 
-RUN apk update && apk add curl jq
+RUN apk add --no-cache \
+        curl \
+        gcc \
+        jq \
+        libxml2 \
+        libxml2-dev \
+        libxslt \
+        libxslt-dev \
+        linux-headers \
+        musl-dev \
+    && pip install -U \
+        lxml
 
 COPY ./automation-tools /usr/lib/archivematica/automation-tools
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Environment Variables
 | `AM_TOOLS_TRANSFER_AM_URL` | The URL to use when connecting to the Archivematica Dashboard. | `http://127.0.0.1` |
 | `AM_TOOLS_TRANSFER_AM_USER` | The username to use when connecting to the Archivematica Dashboard. | None |
 | `AM_TOOLS_TRANSFER_DEPTH` | The "depth" to use for the transfer, as documented in the Automation Tools README. | `1` |
-| `AM_TOOLS_TRANSFER_PATH` | The path to use for the transfer, as documented in the Automation Tools README. | `` |
+| `AM_TOOLS_TRANSFER_LOG_LEVEL` | The log level to use when running transfers, one of `ERROR`, `WARNING`, `INFO` or `DEBUG`. | `INFO` |
+| `AM_TOOLS_TRANSFER_PATH` | The path to use for the transfer, as documented in the Automation Tools README. | `None` |
 | `AM_TOOLS_TRANSFER_PROCESSING_XML` | The name of the XML file to use to configure the MCP during transfer. | `automatedProcessingMCP.xml` |
 | `AM_TOOLS_TRANSFER_SOURCE_DESCRIPTION` | The "description" of the transfer source defined in the Archivematica Storage Service to use as the source for automated transfers. Case sensitive. | None |
 | `AM_TOOLS_TRANSFER_SS_API_KEY` | The API key to use when connecting to the Archivematica Storage Service. | None |

--- a/rootfs/usr/local/bin/setup.sh
+++ b/rootfs/usr/local/bin/setup.sh
@@ -11,7 +11,6 @@ AM_PROCESSING_CONF_FILE="${AM_TOOLS_TRANSFER_PROCESSING_XML:-automatedProcessing
 pip install -r "${AM_TOOLS_HOME}/requirements/base.txt"
 mkdir -p "${AM_TOOLS_CONF}"
 cp "${AM_TOOLS_HOME}/etc/transfers.conf" "${AM_TOOLS_CONF}/"
-cp "${AM_TOOLS_HOME}/etc/transfer-script.sh" "${AM_TOOLS_CONF}/"
 
 # Set up logging
 mkdir -p "/var/log/archivematica/automation-tools"

--- a/rootfs/usr/local/bin/transfer.sh
+++ b/rootfs/usr/local/bin/transfer.sh
@@ -32,10 +32,12 @@ python -m transfers.transfer \
   --api-key "${AM_TOOLS_TRANSFER_AM_API_KEY}" \
   --config-file "/etc/archivematica/automation-tools/transfers.conf" \
   --depth "${AM_TOOLS_TRANSFER_DEPTH:-1}" \
+  --log-level "${AM_TOOLS_TRANSFER_LOG_LEVEL:-INFO}" \
   --ss-api-key "${AM_TOOLS_TRANSFER_SS_API_KEY}" \
   --ss-url "${SS_URL}" \
   --ss-user "${AM_TOOLS_TRANSFER_SS_USER}" \
   --transfer-path "${AM_TOOLS_TRANSFER_PATH}" \
   --transfer-source "${transfer_source_id}" \
   --transfer-type "${AM_TOOLS_TRANSFER_TYPE:-standard}" \
+  --verbose \
   --user "${AM_TOOLS_TRANSFER_AM_USER}"


### PR DESCRIPTION
This addresses issue #11. The actual fix is in https://github.com/artefactual/automation-tools/pull/43 so this remains work-in-progress until that PR has been merged into the base `artefactual/automation-tools`. Once that happens, the `automation-tools` submodule can be updated to point to the right commit so that the required functionality is built into our Docker image.

There are some additional changes to this repo:
* Added base packages to apk install, because these are used to build some of the packages specified in the `requirements.txt` for the Automation Tools
* Made the log level configurable via the `AM_TOOLS_TRANSFER_LOG_LEVEL` environment variable

The first of these is required for a successful build, the latter just makes it easier to debug things.

As mentioned, this PR shouldn't be approved or merged until the proposed change to `artefactual/automation-tools` has been approved and merged.